### PR TITLE
Support nested hierarchy for Managed Configurations, and report the state back with KeyedAppStatesReporter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,4 +38,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.google.code.gson:gson:2.8.9'
+    implementation 'androidx.enterprise:enterprise-feedback:1.1.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,4 +37,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'com.google.code.gson:gson:2.8.9'
 }

--- a/android/src/main/kotlin/io/mway/managed_configurations/BundleTypeAdapterFactory.java
+++ b/android/src/main/kotlin/io/mway/managed_configurations/BundleTypeAdapterFactory.java
@@ -1,0 +1,166 @@
+package io.mway.managed_configurations;
+
+/*
+ * Copyright (C) 2015 Gson Type Adapter Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import android.os.Bundle;
+import android.os.Parcelable;
+import android.util.Pair;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * Type adapter for Android Bundle. It only stores the actual properties set in the bundle
+ *
+ * @author Inderjeet Singh
+ */
+public class BundleTypeAdapterFactory implements TypeAdapterFactory {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(final Gson gson, TypeToken<T> type) {
+        if (!Bundle.class.isAssignableFrom(type.getRawType())) {
+            return null;
+        }
+        return (TypeAdapter<T>) new TypeAdapter<Bundle>() {
+            @Override public void write(JsonWriter out, Bundle bundle) throws IOException {
+                if (bundle == null) {
+                    out.nullValue();
+                    return;
+                }
+                out.beginObject();
+                for (String key : bundle.keySet()) {
+                    out.name(key);
+                    Object value = bundle.get(key);
+                    if (value == null) {
+                        out.nullValue();
+                    } else {
+                        gson.toJson(value, value.getClass(), out);
+                    }
+                }
+                out.endObject();
+            }
+
+            @Override public Bundle read(JsonReader in) throws IOException {
+                switch (in.peek()) {
+                    case NULL:
+                        in.nextNull();
+                        return null;
+                    case BEGIN_OBJECT:
+                        return toBundle(readObject(in));
+                    default: throw new IOException("expecting object: " + in.getPath());
+                }
+            }
+
+            private Bundle toBundle(List<Pair<String, Object>> values) throws IOException {
+                Bundle bundle = new Bundle();
+                for (Pair<String, Object> entry : values) {
+                    String key = entry.first;
+                    Object value = entry.second;
+                    if (value instanceof String) {
+                        bundle.putString(key, (String) value);
+                    } else if (value instanceof Integer) {
+                        bundle.putInt(key, ((Integer)value).intValue());
+                    } else if (value instanceof Long) {
+                        bundle.putLong(key, ((Long)value).longValue());
+                    } else if (value instanceof Double) {
+                        bundle.putDouble(key, ((Double)value).doubleValue());
+                    } else if (value instanceof Parcelable) {
+                        bundle.putParcelable(key, (Parcelable)value);
+                    } else if (value instanceof List) {
+                        List<Pair<String, Object>> objectValues = (List<Pair<String, Object>>) value;
+                        Bundle subBundle = toBundle(objectValues);
+                        bundle.putParcelable(key, subBundle);
+                    } else {
+                        throw new IOException("Unparcelable key, value: " + key + ", "+ value);
+                    }
+                }
+                return bundle;
+            }
+
+            private List<Pair<String, Object>> readObject(JsonReader in) throws IOException {
+                List<Pair<String, Object>> object = new ArrayList<Pair<String, Object>>();
+                in.beginObject();
+                while (in.peek() != JsonToken.END_OBJECT) {
+                    switch (in.peek()) {
+                        case NAME:
+                            String name = in.nextName();
+                            Object value = readValue(in);
+                            object.add(new Pair<String, Object>(name, value));
+                            break;
+                        case END_OBJECT:
+                            break;
+                        default: throw new IOException("expecting object: " + in.getPath());
+                    }
+                }
+                in.endObject();
+                return object;
+            }
+
+            private Object readValue(JsonReader in) throws IOException {
+                switch (in.peek()) {
+                    case BEGIN_ARRAY:
+                        return readArray(in);
+                    case BEGIN_OBJECT:
+                        return readObject(in);
+                    case BOOLEAN:
+                        return in.nextBoolean();
+                    case NULL:
+                        in.nextNull();
+                        return null;
+                    case NUMBER:
+                        return readNumber(in);
+                    case STRING:
+                        return in.nextString();
+                    default: throw new IOException("expecting value: " + in.getPath());
+                }
+            }
+
+            private Object readNumber(JsonReader in) throws IOException {
+                double doubleValue = in.nextDouble();
+                if (doubleValue - Math.ceil(doubleValue) == 0) {
+                    long longValue = (long) doubleValue;
+                    if (longValue >= Integer.MIN_VALUE && longValue <= Integer.MAX_VALUE) {
+                        return (int) longValue;
+                    }
+                    return longValue;
+                }
+                return doubleValue;
+            }
+
+            @SuppressWarnings("rawtypes")
+            private List readArray(JsonReader in) throws IOException {
+                List list = new ArrayList();
+                in.beginArray();
+                while (in.peek() != JsonToken.END_ARRAY) {
+                    Object element = readValue(in);
+                    list.add(element);
+                }
+                in.endArray();
+                return list;
+            }
+        };
+    }
+}

--- a/android/src/main/kotlin/io/mway/managed_configurations/ManagedConfigurationsPlugin.kt
+++ b/android/src/main/kotlin/io/mway/managed_configurations/ManagedConfigurationsPlugin.kt
@@ -66,6 +66,7 @@ class ManagedConfigurationsPlugin : FlutterPlugin, MethodCallHandler, ActivityAw
     override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
         channel?.setMethodCallHandler(null)
         eventChannel?.setStreamHandler(null)
+        flutterPluginBinding.applicationContext.unregisterReceiver(restrictionsReceiver)
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {

--- a/android/src/main/kotlin/io/mway/managed_configurations/ManagedConfigurationsPlugin.kt
+++ b/android/src/main/kotlin/io/mway/managed_configurations/ManagedConfigurationsPlugin.kt
@@ -2,8 +2,8 @@ package io.mway.managed_configurations
 
 import android.app.Activity
 import android.content.*
-import android.util.Log
 import androidx.annotation.NonNull
+import com.google.gson.GsonBuilder
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -13,104 +13,85 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import org.json.JSONException
-import org.json.JSONObject
 
 
 /** ManagedConfigurationsPlugin */
 class ManagedConfigurationsPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
-    /// The MethodChannel that will the communication between Flutter and native Android
-    ///
-    /// This local reference serves to register the plugin with the Flutter Engine and unregister it
-    /// when the Flutter Engine is detached from the Activity
-    private lateinit var channel: MethodChannel
+    private var channel: MethodChannel? = null
+    private var eventChannel: EventChannel? = null
+    private var eventSink: EventSink? = null
+    private var activity: Activity? = null
 
-    ///
-    ///EventChannel which will be used to provide Event to Flutter part
-    ///
-    private lateinit var eventChannel: EventChannel
-    private lateinit var eventStreamHandler: EventChannel.StreamHandler
+    private val restrictionsReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            eventSink?.success(getApplicationRestrictions())
+        }
+    }
 
-
-    private lateinit var context: Context
-    private lateinit var activity: Activity
-
+    private val gson = GsonBuilder().registerTypeAdapterFactory(BundleTypeAdapterFactory())
+        .create()
 
     override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-        context = flutterPluginBinding.applicationContext
+        channel =
+            MethodChannel(flutterPluginBinding.binaryMessenger, "managed_configurations_method")
+        channel!!.setMethodCallHandler(this)
 
-        channel = MethodChannel(flutterPluginBinding.binaryMessenger, "managed_configurations_method")
-        channel.setMethodCallHandler(this)
-
-        eventChannel = EventChannel(flutterPluginBinding.binaryMessenger, "managed_configurations_event");
-
-
-        val restrictionsFilter = IntentFilter(Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED)
-
-        eventChannel.setStreamHandler(object : EventChannel.StreamHandler {
-            override fun onListen(p0: Any?, p1: EventSink) {
-
-                //Create an broadcast receiver
-                val restrictionsReceiver = object : BroadcastReceiver() {
-                    override fun onReceive(context: Context, intent: Intent) {
-                        var restrictionManager = activity.getSystemService(Context.RESTRICTIONS_SERVICE) as RestrictionsManager
-                        // Get the current configuration bundle
-                        val appRestrictions = restrictionManager.applicationRestrictions
-                        val json = JSONObject()
-                        val keys: Set<String> = appRestrictions.keySet()
-                        for (key in keys) {
-                            try {
-                                json.put(key, JSONObject.wrap(appRestrictions.get(key)))
-                            } catch (e: JSONException) {
-                                Log.d("Managed_Configuration", "Failed to put value with key: $key into JSONObject")
-                            }
-                        }
-                        p1.success(json.toString())
-                    }
+        eventChannel =
+            EventChannel(flutterPluginBinding.binaryMessenger, "managed_configurations_event")
+        eventChannel!!.setStreamHandler(
+            object : EventChannel.StreamHandler {
+                override fun onListen(args: Any?, sink: EventChannel.EventSink) {
+                    eventSink = sink
                 }
-                context.registerReceiver(restrictionsReceiver, restrictionsFilter)
+
+                override fun onCancel(args: Any?) {
+                    eventSink = null
+                }
             }
-
-            override fun onCancel(p0: Any?) {}
-        }
         )
-
-
+        flutterPluginBinding.applicationContext.registerReceiver(
+            restrictionsReceiver,
+            IntentFilter(Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED)
+        )
     }
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
-        var restrictionManager = activity.getSystemService(Context.RESTRICTIONS_SERVICE) as RestrictionsManager
-        if (call.method == "getManagedConfigurations") {
-            val json = JSONObject()
-            val keys: Set<String> = restrictionManager.applicationRestrictions.keySet()
-            for (key in keys) {
-                try {
-                    json.put(key, JSONObject.wrap(restrictionManager.applicationRestrictions.get(key)))
-                } catch (e: JSONException) {
-                    Log.d("Managed_Configuration", "Failed to put value with key: $key into JSONObject")
-                }
-            }
-            result.success(json.toString())
-        } else {
-            result.notImplemented()
+        when (call.method) {
+            "getManagedConfigurations" -> result.success(getApplicationRestrictions())
+            else -> result.notImplemented()
         }
     }
 
+
     override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
-        channel.setMethodCallHandler(null)
-    }
-
-    override fun onDetachedFromActivity() {
-    }
-
-    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+        channel?.setMethodCallHandler(null)
+        eventChannel?.setStreamHandler(null)
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-        activity = binding.activity;
+        activity = binding.activity
+    }
+
+    override fun onDetachedFromActivity() {
+        activity = null
+    }
+
+    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+        activity = binding.activity
     }
 
     override fun onDetachedFromActivityForConfigChanges() {
+        activity = null
+    }
+
+    private fun getApplicationRestrictions(): String? {
+        val restrictionManager =
+            activity?.getSystemService(Context.RESTRICTIONS_SERVICE) as RestrictionsManager?
+                ?: return null
+        // Get the current configuration bundle
+        val applicationRestrictions = restrictionManager.applicationRestrictions
+        //val json = JSONObject()
+        return gson.toJson(applicationRestrictions).toString()
     }
 }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -80,14 +80,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -155,7 +155,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/flutter-managed-configuration.iml
+++ b/flutter-managed-configuration.iml
@@ -6,9 +6,14 @@
       <excludeFolder url="file://$MODULE_DIR$/example/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/example/build" />
       <excludeFolder url="file://$MODULE_DIR$/example/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Flutter Plugins" level="project" />
+    <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/flutter-managed-configuration.iml
+++ b/flutter-managed-configuration.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/example/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/example/build" />
+      <excludeFolder url="file://$MODULE_DIR$/example/.pub" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Flutter Plugins" level="project" />
+  </component>
+</module>

--- a/lib/managed_configurations.dart
+++ b/lib/managed_configurations.dart
@@ -4,6 +4,20 @@ import 'dart:convert';
 import 'package:flutter/services.dart';
 
 const String getManagedConfiguration = "getManagedConfigurations";
+const String reportKeyedAppState = "reportKeyedAppState";
+
+enum Severity { SEVERITY_INFO, SEVERITY_ERROR }
+
+extension SeverityExtensions on Severity {
+  int toInteger() {
+    switch (this) {
+      case Severity.SEVERITY_INFO:
+        return 1;
+      case Severity.SEVERITY_ERROR:
+        return 2;
+    }
+  }
+}
 
 class ManagedConfigurations {
   static const MethodChannel _managedConfigurationMethodChannel =
@@ -48,6 +62,23 @@ class ManagedConfigurations {
     } else {
       return null;
     }
+  }
+
+  static Future<void> reportKeyedAppStates(
+    String key,
+    Severity severity,
+    String? message,
+    String? data,
+  ) async {
+    await _managedConfigurationMethodChannel.invokeMethod(
+      reportKeyedAppState,
+      {
+        'key': key,
+        'severity': severity.toInteger(),
+        'message': message,
+        'data': data,
+      },
+    );
   }
 
   static dispose() {

--- a/lib/managed_configurations.dart
+++ b/lib/managed_configurations.dart
@@ -18,12 +18,12 @@ class ManagedConfigurations {
   static Stream<Map<String, dynamic>?> _managedConfigurationsStream =
       _mangedConfigurationsController.stream.asBroadcastStream();
 
-  /// Returns a broadcasst stream which calls on managed app configuration changes
+  /// Returns a broadcast stream which calls on managed app configuration changes
   /// Json will be returned
-  /// Call [dispose] when stream is not more necassary
+  /// Call [dispose] when stream is not more necessary
   static Stream<Map<String, dynamic>?> get mangedConfigurationsStream {
-    if (_actionApplicationRestrictionsChangedubscription == null) {
-      _actionApplicationRestrictionsChangedubscription =
+    if (_actionApplicationRestrictionsChangedSubscription == null) {
+      _actionApplicationRestrictionsChangedSubscription =
           _managedConfigurationEventChannel
               .receiveBroadcastStream()
               .listen((newManagedConfigurations) {
@@ -37,20 +37,20 @@ class ManagedConfigurations {
   }
 
   static StreamSubscription<dynamic>?
-      _actionApplicationRestrictionsChangedubscription;
+      _actionApplicationRestrictionsChangedSubscription;
 
   /// Returns managed app configurations as Json
   static Future<Map<String, dynamic>?> get getManagedConfigurations async {
-    final String? version = await _managedConfigurationMethodChannel
+    final String? rawJson = await _managedConfigurationMethodChannel
         .invokeMethod(getManagedConfiguration);
-    if (version != null) {
-      return json.decode(version);
+    if (rawJson != null) {
+      return json.decode(rawJson);
     } else {
       return null;
     }
   }
 
   static dispose() {
-    _actionApplicationRestrictionsChangedubscription?.cancel();
+    _actionApplicationRestrictionsChangedSubscription?.cancel();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -66,14 +66,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.20.0"


### PR DESCRIPTION
Thanks for your plugin.

I did some modifications to support nested-hierarchy for Managed Configurations. This change mostly relies on the existing BundleTypeAdapterFactory, which can be used with google's gson library.

I also added a way to report the status back to the EMM, so that the EMM knows if the managed value is applied successfully.

This code is not fully tested in production, so be aware.
