### PR TITLE
increase android build version to 36

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,7 +34,7 @@ android {
     }
 
     defaultConfig {
-        compileSdk 31
+        compileSdk 36
         minSdkVersion 21
     }
 


### PR DESCRIPTION
Android sdk 36 requires at least compileSdk Version 35.