### PR TITLE
Fix EventChannel calls from background thread on Android

### DIFF
--- a/android/src/main/kotlin/io/mway/managed_configurations/ManagedConfigurationsPlugin.kt
+++ b/android/src/main/kotlin/io/mway/managed_configurations/ManagedConfigurationsPlugin.kt
@@ -3,6 +3,8 @@ package io.mway.managed_configurations
 import android.app.Activity
 import android.content.*
 import android.util.Log
+import android.os.Handler
+import android.os.Looper
 import androidx.annotation.NonNull
 import androidx.enterprise.feedback.KeyedAppState
 import androidx.enterprise.feedback.KeyedAppStatesReporter
@@ -30,6 +32,7 @@ class ManagedConfigurationsPlugin : FlutterPlugin, MethodCallHandler, ActivityAw
     private val gson = GsonBuilder().registerTypeAdapterFactory(BundleTypeAdapterFactory())
         .create()
     private val executor = Executors.newSingleThreadExecutor()
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     private var reporter: KeyedAppStatesReporter? = null
 
@@ -124,10 +127,14 @@ class ManagedConfigurationsPlugin : FlutterPlugin, MethodCallHandler, ActivityAw
         override fun onReceive(context: Context, intent: Intent) {
             getApplicationRestrictionsAsync(
                 onSuccess = { result ->
-                    eventSink?.success(result)
+                    mainHandler.post {
+                        eventSink?.success(result)
+                    }
                 },
                 onError = { e ->
-                    eventSink?.error("restrictionsReceiver", e.message, Log.getStackTraceString(e))
+                    mainHandler.post {
+                        eventSink?.error("restrictionsReceiver", e.message, Log.getStackTraceString(e))
+                    }
                 }
             )
         }


### PR DESCRIPTION
Fixes #23 

This fixes a crash on Android when managed app configurations are changed while listening to `mangedConfigurationsStream`.

Cause:
`eventSink.success()` / `eventSink.error()` were triggered from the executor background thread in `getApplicationRestrictionsAsync(...)`.

Effect:
Flutter crashes with `FlutterJNI.ensureRunningOnMainThread` when TestDPC or another EMM updates managed configurations.

Fix:
Post EventChannel callbacks back to the main thread using `Handler(Looper.getMainLooper())`.

I verified this on a real Android device provisioned with TestDPC as Device Owner by changing managed configurations multiple times.