### PR TITLE
fix: apply kotlin-android plugin explicitly for KGP 2.x compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,6 +20,7 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
 android {
     if (project.android.hasProperty('namespace')) {
@@ -38,10 +39,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
     }
 }
 


### PR DESCRIPTION
## Problem

`kotlinOptions {}` inside the `android {}` block requires the Kotlin Android plugin (`kotlin-android`) to be applied. Previously this worked implicitly via Flutter tooling, but **Kotlin Gradle Plugin 2.x** no longer registers the `kotlinOptions` extension on the `android` extension unless the plugin is explicitly applied.

This causes the following build error when using the package with KGP 2.0+:

```
Could not find method kotlinOptions() for arguments [...] on extension 'android'
of type com.android.build.gradle.LibraryExtension.
```

## Fix

- Explicitly apply `kotlin-android` plugin in `android/build.gradle`
- Remove the `kotlinOptions` block — `jvmTarget` is already covered by the `compileOptions` `sourceCompatibility` setting which AGP propagates to Kotlin automatically

## Tested with

- Kotlin Gradle Plugin 2.1.0
- Android Gradle Plugin 8.12.0